### PR TITLE
Add steps to disable shallow fetch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,6 +32,8 @@ jobs:
       DOCKER_BUILDKIT: 1
 
     steps:
+    - checkout: self
+      fetchDepth: 0
     - task: PowerShell@2
       inputs:
         filePath: "scripts/Test-ChangesMadeInPath.ps1"


### PR DESCRIPTION
Due to a change in the shallow fetch policy we need to disable shallow fetch before running the script, otherwise the parent git SHA will not be found.

![](https://i.stack.imgur.com/Y3fPj.png)
